### PR TITLE
auto.py: fix replace

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -77,7 +77,7 @@ print('---------------------------------------------------------------------')
 #now slice audio according to start- and end-times in csv
 print('Slicing audio according to start- and end_times of transcript_csvs...')
 for item in glob('./ready_for_slice/*.csv'):
-    wav_item = item.replace('.csv','.wav')
+    wav_item = item.replace('.csv','')
     if os.path.exists(wav_item):
         split_files(item, wav_item)
     else:
@@ -117,7 +117,7 @@ df_files['duration'] = df_files['duration'].apply(convert)
 #drop unnecessary columns
 df_transcripts.drop(['start_times','end_times'], axis=1, inplace=True)
 
-df_files['id'] = df_files['id'].replace('.wav', '', regex=True)
+df_files['id'] = df_files['id'].replace('.wav$', '', regex=True)
 
 #merge on column id
 df_final = pd.merge(df_transcripts, df_files, on='id')


### PR DESCRIPTION
I found these problems when applying auto.py. These may be reason of  [issue #2 ](https://github.com/AlexandaJerry/whisper-vits-japanese/issues/2).
1. 1st wrong call of `replace` would fail finding wav files in some situation
2. 2nd wrong call of `replace` would fail `pd.merge` if filename contains '.wav'