### PR TITLE
requirements.txt: fix torch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ phonemizer==2.2.1
 scipy==1.5.2
 Unidecode==1.1.1
 pyopenjtalk==0.2.0
+torch==1.12.1


### PR DESCRIPTION
`torch 2.0.0` 发布后，由于 `requirements.txt` 未指定 `torch` 版本，`pip` 自动选择的最新版本 `torch` 无法正常运行，故修改为指定可行的 `1.12.1` 版本。